### PR TITLE
Various improvements

### DIFF
--- a/rest_framework_swagger/__init__.py
+++ b/rest_framework_swagger/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '0.3.5+aiotv.4'
+VERSION = '0.3.5+aiotv.5'
 
 DEFAULT_SWAGGER_SETTINGS = {
     'exclude_namespaces': [],

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -17,7 +17,7 @@ from .introspectors import (
     extract_serializer_fields,
 )
 from .compat import OrderedDict
-from .utils import get_serializer_name, template_dict, find_refs, find_used_refs
+from .utils import get_serializer_name, template_dict, find_refs, find_used_refs, get_child
 
 
 class DocumentationGenerator(object):
@@ -283,7 +283,7 @@ class DocumentationGenerator(object):
             if serializer_name in models:
                 return
 
-            child_serializer = getattr(getattr(serializer, 'Meta', None), 'child', None)
+            child_serializer = get_child(serializer)
             if child_serializer:
                 add_serializer_tree(child_serializer, write)
 
@@ -303,7 +303,7 @@ class DocumentationGenerator(object):
         :param serializer: Serializer to describe
         :type serializer: serializer instance
         """
-        child = getattr(getattr(serializer, 'Meta', None), 'child', None) or getattr(serializer, 'child', None)
+        child = get_child(serializer)
         if child and serializer.many:
             child_name = get_serializer_name(child, write=write)
             if child_name not in self.explicit_response_types:

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -177,8 +177,11 @@ class DocumentationGenerator(object):
             operation['responses'] = response_messages
             for filter_ in self._operation_filters:
                 filter_(operation, callback=method_introspector.callback, method=method_introspector.method)
+                if not operation:
+                    break
 
-            operations.append(operation)
+            if operation:
+                operations.append(operation)
 
         return operations
 

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -151,7 +151,7 @@ class DocumentationGenerator(object):
             operation.update(doc_parser.get_operation_extensions())
 
             if doc_parser.yaml_error is not None:
-                operation['notes'] += '<pre>YAMLError:\n {err}</pre>'.format(
+                operation['description'] += '\n\n<pre>YAMLError:\n {err}</pre>'.format(
                     err=doc_parser.yaml_error)
 
             response_messages = {}

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -17,7 +17,7 @@ from .introspectors import (
     extract_serializer_fields,
 )
 from .compat import OrderedDict
-from .utils import extract_base_path, get_serializer_name, template_dict, find_refs, find_used_refs
+from .utils import get_serializer_name, template_dict, find_refs, find_used_refs
 
 
 class DocumentationGenerator(object):
@@ -68,9 +68,12 @@ class DocumentationGenerator(object):
 
     def get_paths(self, endpoints_conf):
         paths_dict = {}
+        base_path = self.config.get('base_path')
         for endpoint in endpoints_conf:
-            # remove the base_path from the begining of the path
-            endpoint['path'] = extract_base_path(path=endpoint['path'], base_path=self.config.get('base_path'))
+            # Can't have paths above the base path in the spec
+            if base_path and not endpoint['path'].startswith(base_path):
+                continue
+            endpoint['path'] = endpoint['path'][len(base_path):]
             path_item = self.get_path_item(endpoint)
             if path_item:
                 paths_dict[endpoint['path']] = path_item

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -36,8 +36,8 @@ class DocumentationGenerator(object):
 
 
     def get_root(self, endpoints_conf):
-        self.default_payload_definition_name = self.config.get("default_payload_definition_name", None)
-        self.default_payload_definition = self.config.get("default_payload_definition", None)
+        self.default_payload_definition_name = self.config.get('default_payload_definition_name', None)
+        self.default_payload_definition = self.config.get('default_payload_definition', None)
         if self.default_payload_definition:
             self.explicit_response_types.update({
                 self.default_payload_definition_name: self.default_payload_definition
@@ -50,9 +50,9 @@ class DocumentationGenerator(object):
                 'version': self.request.version,
                 'description': '',
             })),
-            ('basePath', self.config.get("base_path", '')),
+            ('basePath', self.config.get('base_path', '')),
             ('host', self.config.get('host', self.request.get_host())),
-            ('schemes', self.config.get('schemes', ["https" if self.request.is_secure() else "http"])),
+            ('schemes', self.config.get('schemes', ['https' if self.request.is_secure() else 'http'])),
             ('securityDefinitions', self.config.get('securityDefinitions', {})),
             ('tags', self.config.get('tags', [])),
             ('paths', self.get_paths(endpoints_conf)),
@@ -102,7 +102,7 @@ class DocumentationGenerator(object):
     def get_method_introspectors(self, api_endpoint, introspector):
         return [method_introspector for method_introspector in introspector if
                 isinstance(method_introspector, BaseMethodIntrospector)
-                and not method_introspector.get_http_method() == "OPTIONS"]
+                and not method_introspector.get_http_method() == 'OPTIONS']
 
     def get_tags(self, url_path):
         tags = []
@@ -158,8 +158,8 @@ class DocumentationGenerator(object):
             # set default response reference
             if self.default_payload_definition:
                 response_messages['default'] = {
-                    "schema": {
-                        "$ref": "#/definitions/{}".format(self.default_payload_definition_name)
+                    'schema': {
+                        '$ref': '#/definitions/{}'.format(self.default_payload_definition_name)
                     }
                 }
 
@@ -186,7 +186,7 @@ class DocumentationGenerator(object):
         return operations
 
     def _get_default_response_object(self, operation_method, response_type):
-        if response_type == "object":
+        if response_type == 'object':
             schema = {'type': 'object'}
         else:
             schema = {'$ref': '#/definitions/' + response_type}
@@ -208,12 +208,12 @@ class DocumentationGenerator(object):
 
     def _paginate_response_type(self, response_type, method_introspector):
         doc_parser = method_introspector.yaml_parser
-        definition_name = response_type + "Page"
+        definition_name = response_type + 'Page'
 
-        if response_type == "object":
-            replacement = ("type", "object")
+        if response_type == 'object':
+            replacement = ('type', 'object')
         else:
-            replacement = ("$ref", "#/definitions/{}".format(response_type))
+            replacement = ('$ref', '#/definitions/{}'.format(response_type))
 
         page_definition = doc_parser.get_param('page_definition', self.config.get('default_page_definition'))
         page_definition = template_dict(page_definition, ('$ref', '#/definitions/*'), replacement)
@@ -231,9 +231,9 @@ class DocumentationGenerator(object):
         serializer = introspector.get_request_serializer_class()
         parameters = []
         if serializer:
-            if set(consumes).issubset({"multipart/form-data", "application/x-www-form-encoded"}):
+            if set(consumes).issubset({'multipart/form-data', 'application/x-www-form-encoded'}):
                 parameters.extend(introspector.get_form_parameters())
-            elif getattr(getattr(serializer, "Meta", None), "_in", "body") == "body":
+            elif getattr(getattr(serializer, 'Meta', None), '_in', 'body') == 'body':
                 self.body_serializers.add(serializer)
                 parameters.append(introspector.build_body_parameters())
 
@@ -283,7 +283,7 @@ class DocumentationGenerator(object):
             if serializer_name in models:
                 return
 
-            child_serializer = getattr(getattr(serializer, "Meta", None), "child", None)
+            child_serializer = getattr(getattr(serializer, 'Meta', None), 'child', None)
             if child_serializer:
                 add_serializer_tree(child_serializer, write)
 
@@ -317,7 +317,7 @@ class DocumentationGenerator(object):
             }
 
         data = self._get_serializer_fields(serializer)
-        serializer_type = "object"
+        serializer_type = 'object'
         fields_to_skip = set(data['read_only'] if write else data['write_only'])
         properties = OrderedDict((k, v) for k, v in data['fields'].items()
                                  if k not in fields_to_skip)
@@ -326,7 +326,7 @@ class DocumentationGenerator(object):
             'properties': properties,
             'type': serializer_type
         }
-        required_properties = [i for i in properties.keys() if i in data.get("required", [])]
+        required_properties = [i for i in properties.keys() if i in data.get('required', [])]
         if required_properties:
             definition['required'] = required_properties
 
@@ -390,13 +390,13 @@ class DocumentationGenerator(object):
             view_name = view_name.replace('ViewSet', '')
             view_name = view_name.replace('APIView', '')
             view_name = view_name.replace('View', '')
-            response_type_name = "{view}{method}Response".format(
+            response_type_name = '{view}{method}Response'.format(
                 view=view_name,
                 method=method_inspector.method.title().replace('_', '')
             )
             self.explicit_response_types.update({
                 response_type_name: {
-                    "id": response_type_name,
+                    'id': response_type_name,
                     "properties": response_type
                 }
             })

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -397,7 +397,7 @@ class DocumentationGenerator(object):
             self.explicit_response_types.update({
                 response_type_name: {
                     'id': response_type_name,
-                    "properties": response_type
+                    'properties': response_type
                 }
             })
             return response_type_name

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -107,7 +107,7 @@ class DocumentationGenerator(object):
     def get_tags(self, url_path):
         tags = []
         for matcher in self._tag_matchers:
-            tags.extend(matcher(url_path))
+            tags.extend(matcher(url_path, self.config))
         return tags
 
     def get_operations(self, api_endpoint, introspector):

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -148,6 +148,7 @@ class DocumentationGenerator(object):
                 'tags': doc_parser.get_param(param_name='tags', default=self.get_tags(api_endpoint['path'])),
                 'parameters': self._get_operation_parameters(method_introspector, operation_method, consumes)
             }
+            operation.update(doc_parser.get_operation_extensions())
 
             if doc_parser.yaml_error is not None:
                 operation['notes'] += '<pre>YAMLError:\n {err}</pre>'.format(

--- a/rest_framework_swagger/docgenerator.py
+++ b/rest_framework_swagger/docgenerator.py
@@ -230,7 +230,7 @@ class DocumentationGenerator(object):
         """
         serializer = introspector.get_request_serializer_class()
         parameters = []
-        if method in ('POST', 'PUT', 'PATCH') and serializer:
+        if serializer:
             if set(consumes).issubset({"multipart/form-data", "application/x-www-form-encoded"}):
                 parameters.extend(introspector.get_form_parameters())
             elif getattr(getattr(serializer, "Meta", None), "_in", "body") == "body":

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -6,6 +6,8 @@ import itertools
 import re
 import logging
 
+from django.utils import six
+
 from .compat import strip_tags, get_pagination_attribures
 from .yamlparser import YAMLDocstringParser
 from .constants import INTROSPECTOR_ENUMS, INTROSPECTOR_PRIMITIVES
@@ -152,13 +154,23 @@ class BaseMethodIntrospector(object):
             self._yaml_parser = self.get_yaml_parser()
         return self._yaml_parser
 
+    def _default_to_docs(self, object, key):
+        data = object.get(key, {})
+        if isinstance(data, six.string_types):
+            return {'docs': data}
+        return data
+
     def get_yaml_parser(self):
         parser = YAMLDocstringParser(self)
         parent_parser = YAMLDocstringParser(self.parent)
         new_object = {}
-        new_object.update(parent_parser.object.get("*", {}))
-        new_object.update(parent_parser.object.get(self.method, {}))
+
+        new_object.update(self._default_to_docs(parent_parser.object, "*"))
+        new_object.update(self._default_to_docs(parent_parser.object, self.method))
+
         new_object.update(parser.object)
+        new_object.update(self._default_to_docs(parser.object, self.get_http_method().lower()))
+
         parser.object = new_object
         return parser
 
@@ -214,9 +226,7 @@ class BaseMethodIntrospector(object):
 
     def get_summary(self):
         # If there is no docstring on the method, get class docs
-        return IntrospectorHelper.get_summary(
-            self.callback,
-            self.get_docs() or self.parent.get_description())
+        return IntrospectorHelper.get_summary(self.callback, self.get_description())
 
     def get_operation_id(self):
         """
@@ -239,37 +249,30 @@ class BaseMethodIntrospector(object):
             return []
         return {r.media_type for r in self.callback().get_renderers()}
 
+    def _clean_docs(self, docs):
+        docs = IntrospectorHelper.strip_yaml_from_docstring(docs)
+        docs = IntrospectorHelper.strip_params_from_docstring(docs)
+        return docs
+
     def get_description(self):
         """
         Returns the body of the docstring trimmed before any parameters are
         listed. First, get the class docstring and then get the method's. The
         methods will always inherit the class comments.
         """
-        docstring = ""
+        class_docs = self._clean_docs(get_view_description(self.callback))
+        method_docs = self._clean_docs(formatting.dedent(smart_text(self.get_docs())))
 
-        class_docs = get_view_description(self.callback)
-        class_docs = IntrospectorHelper.strip_yaml_from_docstring(class_docs)
-        class_docs = IntrospectorHelper.strip_params_from_docstring(class_docs)
-        method_docs = self.get_docs()
+        if self.yaml_parser.get_param('replace_docs', False):
+            docstring = method_docs
+        else:
+            docstring = "\n\n".join(filter(None, [class_docs, method_docs]))
 
-        if class_docs is not None:
-            docstring += class_docs + "  \n"
-        if method_docs is not None:
-            method_docs = formatting.dedent(smart_text(method_docs))
-            method_docs = IntrospectorHelper.strip_yaml_from_docstring(
-                method_docs
-            )
-            method_docs = IntrospectorHelper.strip_params_from_docstring(
-                method_docs
-            )
+        explicit_docs = self.yaml_parser.get_param("docs", None)
+        if explicit_docs is not None:
+            docstring = explicit_docs.format(super=docstring)
 
-            if self.yaml_parser.get_param('replace_docs', False):
-                docstring = method_docs
-            else:
-                docstring += '\n' + method_docs
-        docstring = docstring.strip()
-
-        return docstring
+        return docstring.strip()
 
     def get_parameters(self):
         """

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -208,7 +208,7 @@ class BaseMethodIntrospector(object):
 
     def get_request_serializer_class(self):
         serializer = self.yaml_parser.get_yaml_request_serializer_class(self.callback)
-        if serializer is None:
+        if serializer is None and self.get_http_method().lower() in {"post", "put", "patch"}:
             serializer = self.get_serializer_class()
         return serializer
 

--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -288,7 +288,7 @@ class BaseMethodIntrospector(object):
         if query_params:
             params += query_params
 
-        if pagination_params and self.get_http_method() == "GET":
+        if pagination_params:
             params += pagination_params
 
         return params
@@ -387,7 +387,7 @@ class BaseMethodIntrospector(object):
 
     def build_pagination_parameters(self):
         paginator = self.callback.pagination_class if hasattr(self.callback, 'pagination_class') else None
-        if paginator:
+        if paginator and self.yaml_parser.get_param('paginated', self.method == 'list'):
             page = paginator.page_query_param
             size = paginator.page_size_query_param
             if not page:

--- a/rest_framework_swagger/urls.py
+++ b/rest_framework_swagger/urls.py
@@ -2,26 +2,23 @@ from django.conf.urls import patterns
 from django.conf.urls import url
 from rest_framework_swagger.views import SwaggerUIView, Swagger2JSONView
 
+
+def swagger_views(config_name=None, path_prefix='^'):
+    return [
+        url(
+            path_prefix + r'swagger\.json$',
+            Swagger2JSONView.as_view(swagger_config_name=config_name),
+            name='django.swagger.2.0.json.view'
+        ),
+        url(
+            path_prefix + r'$',
+            SwaggerUIView.as_view(swagger_config_name=config_name),
+            name="django.swagger.base.view"
+        ),
+    ]
+
+
 urlpatterns = patterns(
     '',
-    url(
-        r'^(?P<swagger_config_name>[\w]+)/swagger\.json$',
-        Swagger2JSONView.as_view(),
-        name='django.swagger.2.0.json.view'
-    ),
-    url(
-        r'^swagger\.json$',
-        Swagger2JSONView.as_view(),
-        name='django.swagger.2.0.json.view'
-    ),
-    url(
-        r'^(?P<swagger_config_name>[\w]+)/?$',
-        SwaggerUIView.as_view(),
-        name="django.swagger.base.view"
-    ),
-    url(
-        r'^$',
-        SwaggerUIView.as_view(),
-        name="django.swagger.base.view"
-    )
+    *(swagger_views() + swagger_views(path_prefix=r'^(?P<swagger_config_name>[\w]+)/'))
 )

--- a/rest_framework_swagger/utils.py
+++ b/rest_framework_swagger/utils.py
@@ -146,3 +146,14 @@ def find_used_refs(roots, definitions):
         extra_roots = find_refs(definitions[root]) - used_definitions
         used_definitions.update(find_used_refs(extra_roots, definitions))
     return used_definitions
+
+
+def get_child(parent_serializer):
+    """
+    Extract the child serializer from a parent serializer (e.g. ListSerializer).
+    """
+    # DRF handled this differently in older versions, so try both ways
+    meta = getattr(parent_serializer, 'Meta', None)
+    meta_child = getattr(meta, 'child', None)
+    serializer_child = getattr(parent_serializer, 'child', None)
+    return meta_child or serializer_child

--- a/rest_framework_swagger/utils.py
+++ b/rest_framework_swagger/utils.py
@@ -52,17 +52,6 @@ def get_default_value(field):
     return default_value
 
 
-def extract_base_path(path, base_path):
-    """
-    extracts the base_path at the begining of the path
-    e.g:
-        extract_base_path(path="/foo/bar", base_path="/foo") => "/bar"
-    """
-    if path.startswith(base_path):
-        path = path[len(base_path):]
-    return path
-
-
 def do_markdown(docstring):
     # Markdown is optional
     if apply_markdown:

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -43,6 +43,7 @@ class SwaggerUIView(BaseSwaggerView, View):
             'swagger_settings': {
                 'swagger_file': self.get_json_url(request),
                 'user_token': auth_token.key if auth_token else '',
+                'config': self.config,
             }
         }
         response = render_to_response(

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -51,7 +51,7 @@ class SwaggerUIView(BaseSwaggerView, View):
     def get_json_url(self, request):
         json_path = self.config.get("json_path", None)
         if not json_path:
-            json_path = self.config.get('base_path', request.path).rstrip("/") + "/swagger.json"
+            json_path = request.path.rstrip("/") + "/swagger.json"
         return request.build_absolute_uri(json_path)
 
 

--- a/rest_framework_swagger/views.py
+++ b/rest_framework_swagger/views.py
@@ -20,8 +20,10 @@ except IndexError:
 
 
 class BaseSwaggerView(object):
+    swagger_config_name = None
+
     def check_permission(self, request, swagger_config_name):
-        self.config = SwaggerConfig().get_config(swagger_config_name)
+        self.config = SwaggerConfig().get_config(swagger_config_name or self.swagger_config_name)
         if not self.has_permission(request):
             raise PermissionDenied()
 

--- a/rest_framework_swagger/yamlparser.py
+++ b/rest_framework_swagger/yamlparser.py
@@ -525,3 +525,6 @@ class YAMLDocstringParser(object):
         :return : a single parameter found in the docstring
         """
         return self.object.get(param_name, default)
+
+    def get_operation_extensions(self):
+        return {k: v for k, v in self.object.items() if k.startswith("x-")}


### PR DESCRIPTION
- Ensure paths are valid by restricting to only those under the base path
- Allow `x-*` extensions in yaml
- Add methods to generate swagger json and UI at a given URL
- Make operation filters and tag matchers more powerful
- Fix errors caused by root-level ListSerializers
- Allow explicit request serializers on any method
- Only put pagination params on list methods by default, but allow them anywhere with `paginated: true`
- Allow specifying method docs in class docstrings with:

``` yaml
list: "My list docs"
# or
retrieve:
  docs: "My retrieve docs"
```
