### PR TITLE
CORE-565: Default being overridden

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -881,8 +881,6 @@ def extract_serializer_fields(serializer, write=False):
                     field_serializer = "Write{}".format(field_serializer)
                 if not has_many:
                     field_data['$ref'] = '#/definitions/' + field_serializer
-            else:
-                data_type = 'string'
 
             if has_many:
                 field_data['type'] = 'array'


### PR DESCRIPTION
- get_data_type already defaults to 'string', so no need to
  set another default value for data_type here
